### PR TITLE
feat: Implement an add command

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,22 @@ yakiire query --collection products --where '{"Path": "Attributes.size", "Op": "
 {"Attributes":{"color":"red","size":100},"CategoryIDs":["1","2","3"],"ID":"1","Name":"Test Product"}
 ```
 
+### Add
+
+```bash
+yakiire add -c <collection name> <json string>
+```
+
+e.g.
+
+```bash
+yakiire add --collection products '{"Attributes":{"color":"red","size":"100"},"CategoryIDs":["1","2","3"],"ID":"002VQIDE4D","Name":"Test Product"}'
+
+# it shows the doc in JSON format if added successfully
+
+{"Attributes":{"color":"red","size":"100"},"CategoryIDs":["1","2","3"],"ID":"002VQIDE4D","Name":"Test Product"}
+```
+
 ## TODOs
 
 ### Set

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -45,8 +45,8 @@ var addCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		getCtx, _ := context.WithCancel(ctx)
-		res, err := client.Add(getCtx, collectionName, doc)
+		addCtx, _ := context.WithCancel(ctx)
+		res, err := client.Add(addCtx, collectionName, doc)
 		if err != nil {
 			fmt.Printf("error: %+v", err)
 			os.Exit(1)

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/mookjp/yakiire/lib"
+	"github.com/spf13/cobra"
+)
+
+var addCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add a document to a collection",
+	Long:  `Add a single document to a collection with a random ID`,
+	Run: func(cmd *cobra.Command, args []string) {
+		documentStr := args[0]
+		if documentStr == "" {
+			fmt.Printf("The document you entered seems to be empty!")
+			os.Exit(1)
+		}
+
+		var doc interface{}
+		err := json.Unmarshal([]byte(documentStr), &doc)
+		fmt.Println(doc)
+
+		flags := cmd.Flags()
+		collectionName, err := flags.GetString(cmdCollectionsKey)
+		if err != nil {
+			panic(err)
+		}
+
+		config := getConfig(cmd.Root())
+		cred := config.credentialPath
+		projectId := config.projectId
+
+		ctx := context.Background()
+		client, err := lib.NewClient(ctx, &lib.ClientConfig{
+			Credentials: cred,
+			ProjectID:   projectId,
+		})
+		if err != nil {
+			fmt.Printf("error: %+v", err)
+			os.Exit(1)
+		}
+
+		getCtx, _ := context.WithCancel(ctx)
+		res, err := client.Add(getCtx, collectionName, doc)
+		if err != nil {
+			fmt.Printf("error: %+v", err)
+			os.Exit(1)
+		}
+		ctx.Done()
+
+		fmt.Println("Document addded with ID:", res.ID)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(addCmd)
+
+	addCmd.Flags().StringP(cmdCollectionsKey, "c", "", "The collection name to add a document to")
+	err := addCmd.MarkFlagRequired(cmdCollectionsKey)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -53,7 +53,7 @@ var addCmd = &cobra.Command{
 		}
 		ctx.Done()
 
-		fmt.Println(res)
+		fmt.Printf("%s", res)
 	},
 }
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -23,7 +23,10 @@ var addCmd = &cobra.Command{
 
 		var doc interface{}
 		err := json.Unmarshal([]byte(documentStr), &doc)
-		fmt.Println(doc)
+		if err != nil {
+			fmt.Printf("Failed to unmarshal JSON with error: %s", err)
+			os.Exit(1)
+		}
 
 		flags := cmd.Flags()
 		collectionName, err := flags.GetString(cmdCollectionsKey)

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -53,7 +53,7 @@ var addCmd = &cobra.Command{
 		}
 		ctx.Done()
 
-		fmt.Println("Document addded with ID:", res.ID)
+		fmt.Println(res)
 	},
 }
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -21,7 +21,7 @@ var addCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		var doc interface{}
+		var doc map[string]interface{}
 		err := json.Unmarshal([]byte(documentStr), &doc)
 		if err != nil {
 			fmt.Printf("Failed to unmarshal JSON with error: %s", err)

--- a/lib/client.go
+++ b/lib/client.go
@@ -88,11 +88,15 @@ func (c *Client) Query(ctx context.Context, collection string, conditions []*Con
 }
 
 // Add a document into a collection
-func (c *Client) Add(ctx context.Context, collection string, document interface{}) (*firestore.DocumentRef, error) {
+func (c *Client) Add(ctx context.Context, collection string, document interface{}) (*Doc, error) {
 	collectionRef := c.firestore.Collection(collection)
 	res, _, err := collectionRef.Add(ctx, document)
 	if err != nil {
 		return nil, err
 	}
-	return res, nil
+	doc, err := res.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &Doc{data: doc.Data()}, nil
 }

--- a/lib/client.go
+++ b/lib/client.go
@@ -86,3 +86,13 @@ func (c *Client) Query(ctx context.Context, collection string, conditions []*Con
 	}
 	return res, nil
 }
+
+// Add a document into a collection
+func (c *Client) Add(ctx context.Context, collection string, document interface{}) (*firestore.DocumentRef, error) {
+	collectionRef := c.firestore.Collection(collection)
+	res, _, err := collectionRef.Add(ctx, document)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}

--- a/lib/client.go
+++ b/lib/client.go
@@ -88,7 +88,7 @@ func (c *Client) Query(ctx context.Context, collection string, conditions []*Con
 }
 
 // Add a document into a collection
-func (c *Client) Add(ctx context.Context, collection string, document interface{}) (*Doc, error) {
+func (c *Client) Add(ctx context.Context, collection string, document map[string]interface{}) (*Doc, error) {
 	collectionRef := c.firestore.Collection(collection)
 	res, _, err := collectionRef.Add(ctx, document)
 	if err != nil {

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -348,7 +348,7 @@ func TestClient_Add(t *testing.T) {
 	type args struct {
 		ctx        context.Context
 		collection string
-		document   interface{}
+		document   map[string]interface{}
 	}
 	tests := []struct {
 		name    string

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -418,6 +418,12 @@ func TestClient_Add(t *testing.T) {
 			}
 		})
 	}
+
+	h := test.NewHelper()
+	if err := h.DeleteAll(); err != nil {
+		panic(err)
+	}
+	h.Close()
 }
 
 func setup() {

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -354,6 +354,7 @@ func TestClient_Add(t *testing.T) {
 		name    string
 		fields  fields
 		args    args
+		want    string
 		wantErr bool
 	}{
 		{
@@ -377,6 +378,7 @@ func TestClient_Add(t *testing.T) {
 					"Name":        "Another Test Product",
 				},
 			},
+			want:    "{\"Attributes\":{\"color\":\"blue\",\"size\":200},\"CategoryIDs\":[\"3\",\"4\",\"5\"],\"ID\":\"2\",\"Name\":\"Another Test Product\"}",
 			wantErr: false,
 		},
 		{
@@ -393,6 +395,7 @@ func TestClient_Add(t *testing.T) {
 				collection: "products",
 				document:   nil,
 			},
+			want:    "",
 			wantErr: true,
 		},
 	}
@@ -410,8 +413,8 @@ func TestClient_Add(t *testing.T) {
 				}
 				return
 			}
-			if len(got.ID) == 0 {
-				t.Errorf("Client.Add() returned zero length ID")
+			if got.String() != tt.want {
+				t.Errorf("Client.Add().String() = %s, want %v", got.String(), tt.want)
 			}
 		})
 	}

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -335,6 +335,88 @@ func TestClient_Query(t *testing.T) {
 	}
 }
 
+func TestClient_Add(t *testing.T) {
+	client, err := firestore.NewClient(context.Background(), "yakiire")
+	if err != nil {
+		panic(err)
+	}
+
+	type fields struct {
+		config    *ClientConfig
+		firestore *firestore.Client
+	}
+	type args struct {
+		ctx        context.Context
+		collection string
+		document   interface{}
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Adds a doc to the collection",
+			fields: fields{
+				config: &ClientConfig{
+					Credentials: "test",
+					ProjectID:   "yakiire",
+				},
+				firestore: client,
+			},
+			args: args{
+				ctx:        context.Background(),
+				collection: "products",
+				document: map[string]interface{}{
+					"Attributes": map[string]interface{}{
+						"color": "blue", "size": 200,
+					},
+					"CategoryIDs": [...]string{"3", "4", "5"},
+					"ID":          "2",
+					"Name":        "Another Test Product",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "returns an error when the document is nil",
+			fields: fields{
+				config: &ClientConfig{
+					Credentials: "test",
+					ProjectID:   "yakiire",
+				},
+				firestore: client,
+			},
+			args: args{
+				ctx:        context.Background(),
+				collection: "products",
+				document:   nil,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				config:    tt.fields.config,
+				firestore: tt.fields.firestore,
+			}
+			got, err := c.Add(tt.args.ctx, tt.args.collection, tt.args.document)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("Client.Add() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				return
+			}
+			if len(got.ID) == 0 {
+				t.Errorf("Client.Add() returned zero length ID")
+			}
+		})
+	}
+}
+
 func setup() {
 	helper = test.NewHelper()
 	helper.CreateData()

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -381,23 +381,6 @@ func TestClient_Add(t *testing.T) {
 			want:    "{\"Attributes\":{\"color\":\"blue\",\"size\":200},\"CategoryIDs\":[\"3\",\"4\",\"5\"],\"ID\":\"2\",\"Name\":\"Another Test Product\"}",
 			wantErr: false,
 		},
-		{
-			name: "returns an error when the document is nil",
-			fields: fields{
-				config: &ClientConfig{
-					Credentials: "test",
-					ProjectID:   "yakiire",
-				},
-				firestore: client,
-			},
-			args: args{
-				ctx:        context.Background(),
-				collection: "products",
-				document:   nil,
-			},
-			want:    "",
-			wantErr: true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -419,11 +419,11 @@ func TestClient_Add(t *testing.T) {
 		})
 	}
 
-	h := test.NewHelper()
-	if err := h.DeleteAll(); err != nil {
+	helper = test.NewHelper()
+	if err := helper.DeleteAll(); err != nil {
 		panic(err)
 	}
-	h.Close()
+	helper.Close()
 }
 
 func setup() {


### PR DESCRIPTION
`add` takes a document and adds it with a random ID to the specified collection. `Set` in firestore takes an ID as well, so I renamed the method here to `add` to avoid confusion. `Set` would be very similar to this I should think.