### PR TITLE
Fix non-independent tests

### DIFF
--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -12,8 +12,6 @@ import (
 var helper *test.Helper
 
 func TestNewClient(t *testing.T) {
-	setup()
-
 	type args struct {
 		ctx    context.Context
 		config *ClientConfig

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -83,6 +83,8 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestClient_Get(t *testing.T) {
+	setup()
+
 	client, err := firestore.NewClient(context.Background(), "yakiire")
 	if err != nil {
 		panic(err)
@@ -158,9 +160,13 @@ func TestClient_Get(t *testing.T) {
 			}
 		})
 	}
+
+	teardown()
 }
 
 func TestClient_Query(t *testing.T) {
+	setup()
+
 	client, err := firestore.NewClient(context.Background(), "yakiire")
 	if err != nil {
 		panic(err)
@@ -332,9 +338,13 @@ func TestClient_Query(t *testing.T) {
 			}
 		})
 	}
+
+	teardown()
 }
 
 func TestClient_Add(t *testing.T) {
+	setup()
+
 	client, err := firestore.NewClient(context.Background(), "yakiire")
 	if err != nil {
 		panic(err)
@@ -401,11 +411,7 @@ func TestClient_Add(t *testing.T) {
 		})
 	}
 
-	helper = test.NewHelper()
-	if err := helper.DeleteAll(); err != nil {
-		panic(err)
-	}
-	helper.Close()
+	teardown()
 }
 
 func setup() {

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -2,7 +2,6 @@ package lib
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"cloud.google.com/go/firestore"
@@ -65,7 +64,7 @@ func TestNewClient(t *testing.T) {
 		setup()
 
 		if tt.fireStoreErr {
-			helper.Close()
+			teardown()
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
@@ -415,15 +414,20 @@ func setup() {
 }
 
 func teardown() {
+	// Check if helper is initialized
+	if helper == nil {
+		return
+	}
+
+	// Delete all documents and close helper
 	if err := helper.DeleteAll(); err != nil {
-		if err.Error() == "rpc error: code = Canceled desc = grpc: the client connection is closing" {
-			fmt.Printf("couldn't delete docs as the connection was closed intentionally, cause: %+v\n", err)
-			return
-		}
 		panic(err)
 	}
 	err := helper.Close()
 	if err != nil {
 		panic(err)
 	}
+
+	// Set helper to nil to prevent re-teardown
+	helper = nil
 }

--- a/test/helper.go
+++ b/test/helper.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"fmt"
 
 	"google.golang.org/api/iterator"
 
@@ -71,7 +70,7 @@ func (h *Helper) Close() error {
 }
 
 func createProduct1(ctx context.Context, products *firestore.CollectionRef) {
-	res, err := products.Doc("1").Set(ctx, Product{
+	_, err := products.Doc("1").Set(ctx, Product{
 		ID:          "1",
 		Name:        "Test Product",
 		CategoryIDs: []string{"1", "2", "3"},
@@ -83,11 +82,10 @@ func createProduct1(ctx context.Context, products *firestore.CollectionRef) {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("docs were inserted. res: %s\n", res)
 }
 
 func createProduct2(ctx context.Context, products *firestore.CollectionRef) {
-	res, err := products.Doc("2").Set(ctx, Product{
+	_, err := products.Doc("2").Set(ctx, Product{
 		ID:          "2",
 		Name:        "Another Test Product",
 		CategoryIDs: []string{"3", "4", "5"},
@@ -99,11 +97,10 @@ func createProduct2(ctx context.Context, products *firestore.CollectionRef) {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("docs were inserted. res: %s\n", res)
 }
 
 func createProduct3(ctx context.Context, products *firestore.CollectionRef) {
-	res, err := products.Doc("3").Set(ctx, Product{
+	_, err := products.Doc("3").Set(ctx, Product{
 		ID:          "3",
 		Name:        "Another Great Test Product",
 		CategoryIDs: []string{"5", "6", "7"},
@@ -115,5 +112,4 @@ func createProduct3(ctx context.Context, products *firestore.CollectionRef) {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("docs were inserted. res: %s\n", res)
 }


### PR DESCRIPTION
24f2b54: The last test in the `TestNewClient` did not delete the created firestore records which were left over for the `Get` and `Query` to use (and so reordering the tests caused them to fail). This commit changes the `helper.Close()` to a proper `teardown()` call, and so should fail tests for `Get` and `Query`.

941c513: Make all tests use proper `setup()` and `teardown()` so they pass again.