### PR TITLE
feat: Implement delete command

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,20 @@ yakiire add --collection products '{"Attributes":{"color":"red","size":"100"},"C
 {"Attributes":{"color":"red","size":"100"},"CategoryIDs":["1","2","3"],"ID":"002VQIDE4D","Name":"Test Product"}
 ```
 
+### Delete
+
+```bash
+yakiire delete -c <collection name> <document ID>
+```
+
+e.g.
+
+```bash
+yakiire delete --collection products 002VQIDE4D
+
+# No output is returned if the document is deleted or does not exist (default firestore behavior)
+```
+
 ## TODOs
 
 ### Set

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/mookjp/yakiire/lib"
+	"github.com/spf13/cobra"
+)
+
+var delCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a document from a collection",
+	Long:  `Delete a document from a collection with specified ID`,
+	Run: func(cmd *cobra.Command, args []string) {
+		docName := args[0]
+		if docName == "" {
+			fmt.Printf("doc name is required")
+			os.Exit(1)
+		}
+
+		flags := cmd.Flags()
+		collectionName, err := flags.GetString(cmdCollectionsKey)
+		if err != nil {
+			panic(err)
+		}
+
+		config := getConfig(cmd.Root())
+		cred := config.credentialPath
+		projectId := config.projectId
+
+		ctx := context.Background()
+		client, err := lib.NewClient(ctx, &lib.ClientConfig{
+			Credentials: cred,
+			ProjectID:   projectId,
+		})
+		if err != nil {
+			fmt.Printf("error: %+v", err)
+			os.Exit(1)
+		}
+		delCtx, _ := context.WithCancel(ctx)
+		err = client.Delete(delCtx, collectionName, docName)
+		if err != nil {
+			fmt.Printf("error: %+v", err)
+			os.Exit(1)
+		}
+		ctx.Done()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(delCmd)
+
+	delCmd.Flags().StringP(cmdCollectionsKey, "c", "", "The collection name to delete a document from")
+	err := delCmd.MarkFlagRequired(cmdCollectionsKey)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/lib/client.go
+++ b/lib/client.go
@@ -100,3 +100,10 @@ func (c *Client) Add(ctx context.Context, collection string, document map[string
 	}
 	return &Doc{data: doc.Data()}, nil
 }
+
+// Delete a document from a collection
+func (c *Client) Delete(ctx context.Context, collection string, docID string) error {
+	collectionRef := c.firestore.Collection(collection)
+	_, err := collectionRef.Doc(docID).Delete(ctx)
+	return err
+}

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -412,6 +412,68 @@ func TestClient_Add(t *testing.T) {
 	teardown()
 }
 
+func TestClient_Delete(t *testing.T) {
+	setup()
+
+	client, err := firestore.NewClient(context.Background(), "yakiire")
+	if err != nil {
+		panic(err)
+	}
+
+	type fields struct {
+		config    *ClientConfig
+		firestore *firestore.Client
+	}
+	type args struct {
+		ctx        context.Context
+		collection string
+		docID      string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "deletes a doc without error",
+			fields: fields{
+				config: &ClientConfig{
+					Credentials: "test",
+					ProjectID:   "yakiire",
+				},
+				firestore: client,
+			},
+			args: args{
+				ctx:        context.Background(),
+				collection: "products",
+				docID:      "1",
+			},
+			want:    "",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				config:    tt.fields.config,
+				firestore: tt.fields.firestore,
+			}
+			err := c.Delete(tt.args.ctx, tt.args.collection, tt.args.docID)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("Client.Delete() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				return
+			}
+		})
+	}
+
+	teardown()
+}
+
 func setup() {
 	helper = test.NewHelper()
 	helper.CreateData()


### PR DESCRIPTION
Firestore doesn't have _any_ different behavior for the document being deleted or the document not existing, so the only way to know if the document was deleted would be to make a separate `Get` call before deletion. Do we want that?